### PR TITLE
Add model specs and remove btn focus outline

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -198,6 +198,9 @@ body {
 .form-control:focus {
   border-color: #66CDAA !important;
 }
+.btn:focus {
+  outline: none;
+}
 $brand-primary: #66CDAA;
 @import "font-awesome";
 @import "rails_emoji_picker";

--- a/spec/models/chatroom_spec.rb
+++ b/spec/models/chatroom_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Chatroom do
+  describe "Associations" do
+    it { should have_many(:users) }
+    it { should have_many(:chatroom_users) }
+    it { should have_many(:messages) }
+    it { should belong_to(:owner) }
+  end
+end

--- a/spec/models/chatroom_user_spec.rb
+++ b/spec/models/chatroom_user_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ChatroomUser do
+  describe "Associations" do
+    it { should belong_to(:user) }
+    it { should belong_to(:chatroom) }
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Message do
+  describe "Associations" do
+    it { should belong_to(:user) }
+    it { should belong_to(:chatroom) }
+  end
+end


### PR DESCRIPTION
This commit adds more simple model specs and removes an annoying outline
when a btn is focused.